### PR TITLE
Merge pull request #3 from btel/fix-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ tensorboard launches a webserver on a given port (by default 6006). In many
 environments (like dockerized deployments), the port is not visible in the
 external network. To expose it, we use the jupyter-servery-proxy extension to proxy it
 to the jupyter server URL (`/proxy/6006/`, mind the [trailing
-slash](https://github.com/jupyterhub/jupyter-server-proxy/issues/41`)!)
+slash](https://github.com/jupyterhub/jupyter-server-proxy/issues/41)!)
 
 The `tensorboardserverextension.py` file, which is executed by jupyter server on
 start up, launches the tensorboard server.

--- a/train_model.ipynb
+++ b/train_model.ipynb
@@ -178,7 +178,7 @@
     "id": "aQq3UHgmLBpC"
    },
    "source": [
-    "You can now go to the [tensorboard interface](/proxy/6006/) to watch dashboards such as scalars, graphs, histograms, and others."
+    "You can now go to the [tensorboard interface](../proxy/6006/) to watch dashboards such as scalars, graphs, histograms, and others."
    ]
   },
   {


### PR DESCRIPTION
A fix for a broken link in the notebook. Now it should point directly to the tensorboard interface in the binder instance from which the notebook is run.